### PR TITLE
Sim: fix null pointer exception if no sim is inserted

### DIFF
--- a/src/com/android/settings/sim/SimSettings.java
+++ b/src/com/android/settings/sim/SimSettings.java
@@ -445,9 +445,11 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
         }
         simPref.clearItems();
 
-        //Get num of activated Subs
-        for (SubscriptionInfo subInfo : mSubInfoList) {
-            if (subInfo != null && subInfo.mStatus == mSubscriptionManager.ACTIVE) mActCount++;
+        // Get num of activated Subs if mSubInfoList is not null
+        if (mSubInfoList != null) {
+            for (SubscriptionInfo subInfo : mSubInfoList) {
+                if (subInfo != null && subInfo.mStatus == mSubscriptionManager.ACTIVE) mActCount++;
+            }
         }
 
         if (askFirst && mActCount > 1) {


### PR DESCRIPTION
  * mSubInfoList can be null, trying to iterate it using a for each loop
    will trigger a NPE and crash settings

Change-Id: I5d145f800a28514122bf0723bb99fbd9f2c594b0
Signed-off-by: Alexander Martinz <eviscerationls@gmail.com>